### PR TITLE
Added stop editor

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -174,4 +174,7 @@ repositories:
     type: git
     url: git@github.com:Futu-reADS/ehmi_driver_package.git
     version: dev/withUI
-    
+  future_packages/parcelpal_stop_editor:
+    type: git
+    url: git@github.com:Futu-reADS/parcelpal_stop_editor.git
+    version: main


### PR DESCRIPTION
Suggest adding parcelpal_stop_editor to autoware.FTD for ease of editing stops in the field.
This change is tested by running following commands:
~~~~
vcs import src < --recursive
colcon build --symlink-install --packages-select parcelpal_stop_editor --cmake-args -DCMAKE_BUILD_TYPE=Release
ros2 launch parcelpal_stop_editor parcelpal_stop_editor_rviz.launch.xml pointcloud_map_file:=facility_pointcloud_map_subsampled.pcd
~~~~


**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
